### PR TITLE
initialize docker file and docker compose for new front

### DIFF
--- a/mc_web_console_api/Dockerfile.local
+++ b/mc_web_console_api/Dockerfile.local
@@ -1,0 +1,36 @@
+## Stage 1 - Go Build Env
+FROM golang:1.22.3-alpine AS build
+
+RUN apk add --no-cache gcc libc-dev musl-dev curl npm wget
+
+RUN mkdir -p /util
+WORKDIR /util
+RUN wget https://github.com/gobuffalo/cli/releases/download/v0.18.14/buffalo_0.18.14_Linux_x86_64.tar.gz \
+    && tar -xvzf buffalo_0.18.14_Linux_x86_64.tar.gz \
+    && mv buffalo /usr/local/bin/buffalo \
+    && rm buffalo_0.18.14_Linux_x86_64.tar.gz
+
+ENV GOPROXY http://proxy.golang.org
+ENV CGO_ENABLED=1
+
+RUN mkdir -p /src/mc-web-console-api
+WORKDIR /src/mc-web-console-api
+ADD . .
+
+RUN go mod download
+RUN buffalo build --static -o /bin/api
+
+## Stage 2 - Application Deploy
+FROM debian:buster-slim as deploy
+
+WORKDIR /app/
+COPY --from=build /bin/api .
+COPY --from=build /src/mc-web-console-api/conf /app/conf
+
+ENV API_ADDR 0.0.0.0
+ENV API_PORT 3000
+
+ENV MCIAM_USE=true
+
+EXPOSE 3000
+CMD bash -c 'until /app/api migrate; do echo "Migration failed. Retrying in 10 seconds..."; sleep 10; done; /app/api > /app/api.log 2>&1 &  tail -f /app/api.log & wait'

--- a/mc_web_console_new_front/.dockerignore
+++ b/mc_web_console_new_front/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/mc_web_console_new_front/Dockerfile
+++ b/mc_web_console_new_front/Dockerfile
@@ -1,0 +1,28 @@
+## Stage 1: Application Build
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+RUN npm install --legacy-peer-deps --save-prod
+
+COPY . .
+
+RUN npm run build
+
+## Stage 2: Run Build Application
+FROM nginx:stable-alpine AS deploy
+
+WORKDIR /app
+
+COPY --from=build /app/nginx.conf /etc/nginx/conf.d
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY --from=build /app/entrypoint.sh /app/entrypoint.sh
+RUN rm /etc/nginx/conf.d/default.conf
+
+RUN chmod +x /app/entrypoint.sh
+
+EXPOSE 80
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/mc_web_console_new_front/entrypoint.sh
+++ b/mc_web_console_new_front/entrypoint.sh
@@ -3,7 +3,3 @@
 trap "nginx -s stop" SIGTERM
 
 nginx -g "daemon off;"
-
-while :; do
-  sleep 1
-done

--- a/mc_web_console_new_front/entrypoint.sh
+++ b/mc_web_console_new_front/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+trap "nginx -s stop" SIGTERM
+
+nginx -g "daemon off;"
+
+while :; do
+  sleep 1
+done

--- a/mc_web_console_new_front/nginx.conf
+++ b/mc_web_console_new_front/nginx.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    error_page 404 /index.html;
+
+    error_log /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+}

--- a/mc_web_console_new_front/package-lock.json
+++ b/mc_web_console_new_front/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cloudforet-test/mirinae": "^2.0.0-dev125",
+        "@cloudforet-test/mirinae": "2.0.0-dev171",
         "axios": "^1.7.2",
         "pinia": "^2.1.7",
         "postcss-loader": "^8.1.1",
@@ -165,9 +165,10 @@
       "integrity": "sha512-cLcGizTrrUNA2EYE3MBmEDt2tQv1joVP1Q3oDisZ5nw0MZDx2kcgEXM+/kZpfa/PAkFvYVhRUZwytIQWoN3V/w=="
     },
     "node_modules/@cloudforet-test/mirinae": {
-      "version": "2.0.0-dev125",
-      "resolved": "https://registry.npmjs.org/@cloudforet-test/mirinae/-/mirinae-2.0.0-dev125.tgz",
-      "integrity": "sha512-tSj4rQUggA4fIRJMs+lHB0nkAtbNtm1B/KQsip/6yqsh0qkIgVrGhCMD5NI+/c6HGza3IjmTwbklKnEAYYYtCA==",
+      "version": "2.0.0-dev171",
+      "resolved": "https://registry.npmjs.org/@cloudforet-test/mirinae/-/mirinae-2.0.0-dev171.tgz",
+      "integrity": "sha512-COJ/V267OU4R6QZpOKbP6D1b2RIf+HHtlxtxiyOlqPovMfnQcbB9xkxHHbHwvnaNCnz/vAiLkhZdfaz7k2rxSQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@egjs/vue-flicking": "^3.7.4",
         "@faker-js/faker": "^7.3.0",
@@ -199,7 +200,7 @@
         "v-click-outside": "^3.0.1",
         "v-tooltip": "^2.0.3",
         "velocity-animate": "^1.5.2",
-        "vue": "^2.7.15",
+        "vue": "2.7.16",
         "vue-filepond": "^6.0.3",
         "vue-focus": "^2.1.0",
         "vue-fragment": "^1.5.1",
@@ -208,7 +209,7 @@
         "vue-js-toggle-button": "^1.3.3",
         "vue-notification": "^1.3.20",
         "vue-svgicon": "^3.2.9",
-        "vue-template-compiler": "^2.7.15",
+        "vue-template-compiler": "2.7.16",
         "vuedraggable": "^2.24.3",
         "webfontloader": "^1.6.28"
       }

--- a/mc_web_console_new_front/package.json
+++ b/mc_web_console_new_front/package.json
@@ -15,7 +15,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "@cloudforet-test/mirinae": "^2.0.0-dev125",
+    "@cloudforet-test/mirinae": "2.0.0-dev171",
     "axios": "^1.7.2",
     "pinia": "^2.1.7",
     "postcss-loader": "^8.1.1",

--- a/scripts/docker-compose-vue.yaml
+++ b/scripts/docker-compose-vue.yaml
@@ -1,0 +1,52 @@
+version: '3.9'
+
+services:
+  mc-web-console-api:
+    build: 
+      context: ../mc_web_console_api
+      dockerfile: Dockerfile.local
+    container_name: mc-web-console-api
+    depends_on:
+      - mc-web-console-postgres
+    ports:
+      - "3000:3000"
+    environment:
+      GO_ENV: development # production | development # Please CHANGE ME (OPTIONAL)
+      GODEBUG: netdns=go
+      DEV_DATABASE_URL: postgres://mcwebadmin:mcwebadminpassword@mc-web-console-postgres:5432/mcwebconsoledbdev # Please CHANGE ME (OPTIONAL)
+      PROD_DATABASE_URL: postgres://mcwebadmin:mcwebadminpassword@mc-web-console-postgres:5432/mcwebconsoledbprod # Please CHANGE ME (OPTIONAL)
+    restart: unless-stopped
+    networks:
+      - mc-web-console-front
+      - mc-web-console-back
+  
+  mc-web-console-front:
+    build:
+      context: ../mc_web_console_new_front
+      dockerfile: Dockerfile
+    container_name: mc-web-console-front
+    depends_on:
+      - mc-web-console-api
+    ports:
+      - "80:80"
+    restart: unless-stopped
+    networks:
+      - mc-web-console-front
+      
+
+  mc-web-console-postgres:
+    image: postgres:14-alpine
+    container_name: mc-web-console-postgres
+    volumes:
+     - ~/.m-cmp/mc-web-console/postgresql/data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: mcwebconsoledbdev # [mcwebconsoledbdev / mcwebconsoledbprod] # Please CHANGE ME (OPTIONAL)
+      POSTGRES_USER: mcwebadmin # Please CHANGE ME (OPTIONAL)
+      POSTGRES_PASSWORD: mcwebadminpassword # Please CHANGE ME (OPTIONAL)
+    restart: unless-stopped
+    networks:
+      - mc-web-console-back
+
+networks:
+  mc-web-console-front:
+  mc-web-console-back:


### PR DESCRIPTION
# 작업 내용
- docker image on nginx
- api docker image 작성
- docker compose for new dev 작성
- nginx conf 작성

## 상세 내용
- frontend 의 빌드된 정적 파일을 nginx 기반의 웹 서버에서 작동할 수 있도록 dockerfile 을 작성하였습니다.
- 기존에 빌드된 이미지는 front 와 backend 를 동시에 빌드하고 실행하는 이미지이기 때문에 분리하여 실행할 수 없습니다. backend 를 로컬 실행을 위한 Dockerfile.local 을 통해 별개 실행 가능하도록 작업했습니다.
- front 와 backend 로 나뉘어 작동하는 docker compose 를 작성했습니다.
- 추가적으로 단일 정적 파일로 웹 서버를 통해 제공되는 방식이기 때문에 url 라우팅에 대해 /index.html 로 라우팅 될 수 있도록 nginx.conf 파일을 작성하고 해당 파일을 이미지 빌드 시점에 copy 하도록 하였습니다.

## 이슈 사항
- api 서버의 실행을 위해선 mc_web_console_api 의 conf/api.yaml 이 반드시 필요합니다. 해당 파일을 읽어 다른 서브 시스템으로 요청을 포워딩하는 방식으로 개발이 되어 있기 때문에 해당 파일이 필수입니다.
- api 서버에서 api.yaml 에 설정된 endpoint 를 사용합니다. 환경 변수에 설정 가능한 내용이 반영되지 않기 때문에 명확한 방식으로 변경이 필요해 보입니다.